### PR TITLE
Update Api.class.php

### DIFF
--- a/_protected/framework/Geo/Map/Api.class.php
+++ b/_protected/framework/Geo/Map/Api.class.php
@@ -449,7 +449,7 @@ class Api
      */
     public function geocoding($address)
     {
-        $url = 'https://maps.googleapis.com/maps/api/geocode/json?address=' . urlencode($address) . '&amp;sensor=true&amp;key=' . $this->key;
+        $url = 'https://maps.googleapis.com/maps/api/geocode/json?address=' . urlencode($address) . '&amp;key=' . $this->key;
 
         if (function_exists('curl_init')) {
             $data = $this->getContent($url);


### PR DESCRIPTION
Though it won't stop working, the sensor parameter is no longer required for the Google Maps JavaScript API. This is indicated by google Developer Error Code 'SensorNotRequired' and thought it is a good idea to clean it.